### PR TITLE
Damage xeno fixes

### DIFF
--- a/Resources/Prototypes/_MC/Entities/Mobs/Xeno/Tier3/boiler.yml
+++ b/Resources/Prototypes/_MC/Entities/Mobs/Xeno/Tier3/boiler.yml
@@ -92,11 +92,11 @@
   - type: AcidBloodSplash
     damage:
       types:
-        MCBurn: 30
+        MCBurn: 27.5
     minimalTriggerDamage: 5
     baseHitProbability: 100
     baseSplashTriggerProbability: 40
-    splashCooldown: 0.05
+    splashCooldown: 3
   # Utilities
   - type: MCXenoPlaceStructure
   - type: AcidTrap # TODO: Make MC component

--- a/Resources/Prototypes/_MC/Entities/Objects/Xeno/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_MC/Entities/Objects/Xeno/Projectiles/projectiles.yml
@@ -9,7 +9,7 @@
   - type: Projectile
     damage:
       types:
-        MCBurn: 20
+        MCBurn: 5
   - type: XenoProjectile
     deleteOnFriendlyXeno: false
   - type: ProjectileMaxRange
@@ -17,6 +17,10 @@
   - type: MCXenoSpawnAcidSprayOnTerminating
     spawn: MCXenoAcidSpraySpit
   - type: MCXenoProjectileTargetingTurf
+  - type: XenoSlowingSpitProjectile
+    superSlow: false
+    slow: 1
+    paralyze: 1
 
 - type: entity
   parent: MCXenoProjectile


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Кровь бойлера имеет к/д в 3 секунды, урон меньше на 2.5 бюрна 
Рассеяный плевок наносит на 15 урона меньше (С 120 до 30). Плевки оглушают на секунду

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://discord.com/channels/1389812944405008536/1498292392149647462/1498292392149647462
https://discord.com/channels/1389812944405008536/1512792253754511523/1512792253754511523